### PR TITLE
Add .NET Standard support

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -422,27 +422,27 @@ dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
 
 dotnet_naming_symbols.interface.applicable_kinds = interface
 dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.interface.required_modifiers = 
+dotnet_naming_symbols.interface.required_modifiers =
 
 dotnet_naming_symbols.private_property.applicable_kinds = property
 dotnet_naming_symbols.private_property.applicable_accessibilities = private
-dotnet_naming_symbols.private_property.required_modifiers = 
+dotnet_naming_symbols.private_property.required_modifiers =
 
 dotnet_naming_symbols.private_method.applicable_kinds = method
 dotnet_naming_symbols.private_method.applicable_accessibilities = private
-dotnet_naming_symbols.private_method.required_modifiers = 
+dotnet_naming_symbols.private_method.required_modifiers =
 
 dotnet_naming_symbols.private_enum.applicable_kinds = enum
 dotnet_naming_symbols.private_enum.applicable_accessibilities = private
-dotnet_naming_symbols.private_enum.required_modifiers = 
+dotnet_naming_symbols.private_enum.required_modifiers =
 
 dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
 dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
-dotnet_naming_symbols.types.required_modifiers = 
+dotnet_naming_symbols.types.required_modifiers =
 
 dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
 dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, protected, protected_internal, private_protected
-dotnet_naming_symbols.non_field_members.required_modifiers = 
+dotnet_naming_symbols.non_field_members.required_modifiers =
 
 dotnet_naming_symbols.private_static_method.applicable_kinds = method
 dotnet_naming_symbols.private_static_method.applicable_accessibilities = private
@@ -462,23 +462,23 @@ dotnet_naming_symbols.private_readonly_fields.required_modifiers = readonly
 
 dotnet_naming_symbols.private_fields.applicable_kinds = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = private
-dotnet_naming_symbols.private_fields.required_modifiers = 
+dotnet_naming_symbols.private_fields.required_modifiers =
 
 ## Naming styles
 
-dotnet_naming_style.pascal_case.required_prefix = 
-dotnet_naming_style.pascal_case.required_suffix = 
-dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.required_prefix =
+dotnet_naming_style.pascal_case.required_suffix =
+dotnet_naming_style.pascal_case.word_separator =
 dotnet_naming_style.pascal_case.capitalization = pascal_case
 
 dotnet_naming_style.begins_with_i.required_prefix = I
-dotnet_naming_style.begins_with_i.required_suffix = 
-dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.required_suffix =
+dotnet_naming_style.begins_with_i.word_separator =
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
 
-dotnet_naming_style.camel_case.required_prefix = 
-dotnet_naming_style.camel_case.required_suffix = 
-dotnet_naming_style.camel_case.word_separator = 
+dotnet_naming_style.camel_case.required_prefix =
+dotnet_naming_style.camel_case.required_suffix =
+dotnet_naming_style.camel_case.word_separator =
 dotnet_naming_style.camel_case.capitalization = camel_case
 
 ##################
@@ -820,3 +820,6 @@ dotnet_diagnostic.IL3000.severity = warning
 dotnet_diagnostic.IL3001.severity = warning
 dotnet_diagnostic.IL3002.severity = warning
 dotnet_diagnostic.IL3003.severity = warning
+
+# https://github.com/dotnet/roslyn-analyzers/issues/7192
+dotnet_diagnostic.CA1515.severity = none

--- a/KeepAChangelogParser.Tests/Extensions/AssertExtensions.cs
+++ b/KeepAChangelogParser.Tests/Extensions/AssertExtensions.cs
@@ -70,10 +70,9 @@ namespace KeepAChangelogParser.Tests.Extensions
           actualMaxStringLength;
 
         List<CutElement>? expectedJsonStringCollectionToCut =
-          expectedJsonStringCollection.
+          [.. expectedJsonStringCollection.
             Select((x, index) => new CutElement() { Element = x, Index = index }).
-            Where(x => x.Element.Length > chunkSize).
-            ToList();
+            Where(x => x.Element.Length > chunkSize)];
 
         for (int index1 = 0; index1 < expectedJsonStringCollectionToCut.Count; index1++)
         {
@@ -119,13 +118,12 @@ namespace KeepAChangelogParser.Tests.Extensions
         foreach (var x in actualJsonStringCollectionToCut)
         {
           List<string> lines =
-            Enumerable.
+            [.. Enumerable.
               Range(0, (x.Element.Length / chunkSize) + 1).
               Select(i => x.Element.
                 Substring(
                   i * chunkSize,
-                  x.Element.Length - (chunkSize * i) >= chunkSize ? chunkSize : x.Element.Length - (chunkSize * i))).
-              ToList();
+                  x.Element.Length - (chunkSize * i) >= chunkSize ? chunkSize : x.Element.Length - (chunkSize * i)))];
 
           actualJsonStringCollection.
             RemoveAt(x.Index);

--- a/KeepAChangelogParser.Tests/KeepAChangelogParser.Tests.csproj
+++ b/KeepAChangelogParser.Tests/KeepAChangelogParser.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <OutputType>Library</OutputType>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -25,32 +25,32 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.3">
+    <PackageReference Include="coverlet.collector" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="6.0.3">
+    <PackageReference Include="coverlet.msbuild" Version="6.0.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.7.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.7.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.8.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.8.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="ReportGenerator" Version="5.4.3" />
+    <PackageReference Include="ReportGenerator" Version="5.4.4" />
     <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KeepAChangelogParser.Wpf.SampleApp/CompositionRoot/KeepAChangelogParserComposer.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/CompositionRoot/KeepAChangelogParserComposer.cs
@@ -11,7 +11,7 @@ namespace KeepAChangelogParser.Wpf.SampleApp.CompositionRoot
     {
       _ = Guard.Against.Null(container, nameof(container));
 
-      container.Register(typeof(IChangelogParser), typeof(ChangelogParser), Lifestyle.Singleton);
+      container.Register<IChangelogParser, ChangelogParser>(Lifestyle.Singleton);
     }
   }
 }

--- a/KeepAChangelogParser.Wpf.SampleApp/CompositionRoot/KeepAChangelogWpfSampleAppComposer.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/CompositionRoot/KeepAChangelogWpfSampleAppComposer.cs
@@ -18,15 +18,15 @@ namespace KeepAChangelogParser.Wpf.SampleApp.CompositionRoot
     {
       _ = Guard.Against.Null(container, nameof(container));
 
-      container.Register(typeof(IReleaseNotesWindowService), typeof(ReleaseNotesWindowService), Lifestyle.Singleton);
-      container.Register(typeof(IReleaseNotesWindowClosedEventCommand), typeof(ReleaseNotesWindowClosedEventCommand), Lifestyle.Singleton);
-      container.Register(typeof(IReleaseNotesWindowClickHyperlinkCommand), typeof(ReleaseNotesWindowClickHyperlinkCommand), Lifestyle.Singleton);
-      container.Register(typeof(IReleaseNotesWindowClickOkCommand), typeof(ReleaseNotesWindowClickOkCommand), Lifestyle.Singleton);
-      container.Register(typeof(IReleaseNotesWindowView), typeof(ReleaseNotesWindowView), Lifestyle.Singleton);
-      container.Register(typeof(IReleaseNotesWindowViewModel), typeof(ReleaseNotesWindowViewModel), Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowService, ReleaseNotesWindowService>(Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowClosedEventCommand, ReleaseNotesWindowClosedEventCommand>(Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowClickHyperlinkCommand, ReleaseNotesWindowClickHyperlinkCommand>(Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowClickOkCommand, ReleaseNotesWindowClickOkCommand>(Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowView, ReleaseNotesWindowView>(Lifestyle.Singleton);
+      container.Register<IReleaseNotesWindowViewModel, ReleaseNotesWindowViewModel>(Lifestyle.Singleton);
 
-      container.Register(typeof(IChangelogService), typeof(ChangelogService), Lifestyle.Singleton);
-      container.Register(typeof(IFileService), typeof(FileService), Lifestyle.Singleton);
+      container.Register<IChangelogService, ChangelogService>(Lifestyle.Singleton);
+      container.Register<IFileService, FileService>(Lifestyle.Singleton);
     }
   }
 }

--- a/KeepAChangelogParser.Wpf.SampleApp/Contracts/IChangelogService.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/Contracts/IChangelogService.cs
@@ -5,7 +5,7 @@ namespace KeepAChangelogParser.Wpf.SampleApp.Contracts
 {
   public interface IChangelogService
   {
-    Result<Changelog> ReadChangelog(
+    public Result<Changelog> ReadChangelog(
       string filePath
     );
   }

--- a/KeepAChangelogParser.Wpf.SampleApp/Contracts/IRelayCommand.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/Contracts/IRelayCommand.cs
@@ -4,10 +4,10 @@ namespace KeepAChangelogParser.Wpf.SampleApp.Contracts
 {
   public interface IRelayCommand
   {
-    event EventHandler? CanExecuteChanged;
+    public event EventHandler? CanExecuteChanged;
 
-    bool CanExecute(object? parameter);
+    public bool CanExecute(object? parameter);
 
-    void Execute(object? parameter);
+    public void Execute(object? parameter);
   }
 }

--- a/KeepAChangelogParser.Wpf.SampleApp/Contracts/IStartupService.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/Contracts/IStartupService.cs
@@ -4,7 +4,7 @@ namespace KeepAChangelogParser.Wpf.SampleApp.Contracts
 {
   public interface IStartupService
   {
-    void Execute(
+    public void Execute(
       StartupEventArgs startupEventArgs
     );
   }

--- a/KeepAChangelogParser.Wpf.SampleApp/Contracts/ReleaseNotesWindow/IReleaseNotesWindowService.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/Contracts/ReleaseNotesWindow/IReleaseNotesWindowService.cs
@@ -4,6 +4,6 @@ namespace KeepAChangelogParser.Wpf.SampleApp.Contracts.ReleaseNotesWindow
 {
   public interface IReleaseNotesWindowService
   {
-    Result Initialize();
+    public Result Initialize();
   }
 }

--- a/KeepAChangelogParser.Wpf.SampleApp/Contracts/ReleaseNotesWindow/IReleaseNotesWindowView.cs
+++ b/KeepAChangelogParser.Wpf.SampleApp/Contracts/ReleaseNotesWindow/IReleaseNotesWindowView.cs
@@ -2,14 +2,14 @@
 {
   public interface IReleaseNotesWindowView
   {
-    object DataContext { get; set; }
+    public object DataContext { get; set; }
 
-    void Close();
+    public void Close();
 
-    void Hide();
+    public void Hide();
 
-    void InitializeComponent();
+    public void InitializeComponent();
 
-    bool? ShowDialog();
+    public bool? ShowDialog();
   }
 }

--- a/KeepAChangelogParser.Wpf.SampleApp/KeepAChangelogParser.Wpf.SampleApp.csproj
+++ b/KeepAChangelogParser.Wpf.SampleApp/KeepAChangelogParser.Wpf.SampleApp.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net9.0-windows</TargetFramework>
     <UseWPF>true</UseWPF>
     <AnalysisLevel>latest</AnalysisLevel>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
@@ -37,8 +37,8 @@
 
   <ItemGroup>
     <PackageReference Include="Ardalis.GuardClauses" Version="5.0.0" />
-    <PackageReference Include="CSharpFunctionalExtensions" Version="3.4.3" />
-    <PackageReference Include="KeepAChangeLogParser" Version="1.2.5" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="3.5.1" />
+    <PackageReference Include="KeepAChangeLogParser" Version="1.2.6" />
     <PackageReference Include="Markdig.Wpf" Version="0.5.0.1" />
     <PackageReference Include="Microsoft.Xaml.Behaviors.Wpf" Version="1.1.135" />
     <PackageReference Include="SimpleInjector" Version="5.5.0" />
@@ -46,15 +46,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KeepAChangelogParser/ChangelogParser.cs
+++ b/KeepAChangelogParser/ChangelogParser.cs
@@ -17,7 +17,11 @@ namespace KeepAChangelogParser
     private readonly INewLineService newLineService = new NewLineService();
     private readonly IChangelogTokenizer changelogTokenizer = new ChangelogTokenizer();
 
+#if NET8_0_OR_GREATER
     private static readonly char[] carriageReturnLineFeedArray = ['\r', '\n'];
+#else
+    private static readonly char[] carriageReturnLineFeedArray = new char[] { '\r', '\n' };
+#endif
 
     /// <inheritdoc/>
     [SuppressMessage("Style", "IDE0046", Justification = "Simplification of if statement makes code unreadable")]
@@ -36,8 +40,10 @@ namespace KeepAChangelogParser
       IEnumerable<ChangelogToken> tokenCollection =
         this.changelogTokenizer.Tokenize(text, determineLineEndingsResult.Value);
 
+#pragma warning disable IDE0306 // Simplify collection initialization
       Stack<ChangelogToken> tokenStack =
         new Stack<ChangelogToken>(tokenCollection.Reverse());
+#pragma warning restore IDE0306 // Simplify collection initialization
 
       Result<Changelog> changelogResult =
         Result.Success(new Changelog());

--- a/KeepAChangelogParser/Contracts/IChangelogTokenizer.cs
+++ b/KeepAChangelogParser/Contracts/IChangelogTokenizer.cs
@@ -5,7 +5,7 @@ namespace KeepAChangelogParser.Contracts
 {
   internal interface IChangelogTokenizer
   {
-    IEnumerable<ChangelogToken> Tokenize(
+    public IEnumerable<ChangelogToken> Tokenize(
       string text,
       string newLine
     );

--- a/KeepAChangelogParser/Contracts/INewLineService.cs
+++ b/KeepAChangelogParser/Contracts/INewLineService.cs
@@ -4,7 +4,7 @@ namespace KeepAChangelogParser.Contracts
 {
   internal interface INewLineService
   {
-    Result<string> DetermineLineEndings(
+    public Result<string> DetermineLineEndings(
       string text
     );
   }

--- a/KeepAChangelogParser/IChangelogParser.cs
+++ b/KeepAChangelogParser/IChangelogParser.cs
@@ -14,7 +14,7 @@ namespace KeepAChangelogParser
     /// <param name="text">The <see cref="string"/> instance that contains the keepachangelog markdown text.</param>
     /// <returns>An instance of <see cref="Result"/> class containing an instance of <see cref="Changelog"/> class,
     /// when successful; otherwise, the error message.</returns>
-    Result<Changelog> Parse(
+    public Result<Changelog> Parse(
       string text
     );
   }

--- a/KeepAChangelogParser/KeepAChangelogParser.csproj
+++ b/KeepAChangelogParser/KeepAChangelogParser.csproj
@@ -65,7 +65,7 @@
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KeepAChangelogParser/KeepAChangelogParser.csproj
+++ b/KeepAChangelogParser/KeepAChangelogParser.csproj
@@ -8,7 +8,7 @@
     <AssemblyTitle>KeepAChangeLogParser</AssemblyTitle>
     <NeutralLanguage>en-US</NeutralLanguage>
     <VersionPrefix>1.2.6.0</VersionPrefix>
-    <TargetFrameworks>net462;netcoreapp3.1;net5.0;net6.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;net8.0;net9.0</TargetFrameworks>
     <SignAssembly Condition="'$(Configuration)' == 'Release_Signed'">true</SignAssembly>
     <PackageId>KeepAChangeLogParser</PackageId>
     <PackageId Condition="'$(SignAssembly)' == 'true'">KeepAChangeLogParser.Signed</PackageId>
@@ -38,7 +38,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <WarningsAsErrors>nullable</WarningsAsErrors>
-    <LangVersion>latest</LangVersion>
+    <LangVersion Condition="'$(TargetFramework)' == 'netstandard2.0'">8.0</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
@@ -61,11 +61,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <None Include="readme.md" Pack="true" PackagePath=""/>
+    <None Include="readme.md" Pack="true" PackagePath="" />
   </ItemGroup>
   
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.4">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -77,7 +77,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="CSharpFunctionalExtensions" Version="3.4.3" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="3.5.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.PublicApiAnalyzers" Version="3.3.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -86,15 +86,15 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.CodeAnalysis.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.12.10">
+    <PackageReference Include="Roslynator.Formatting.Analyzers" Version="4.13.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/KeepAChangelogParser/Services/ChangelogTokenizer.cs
+++ b/KeepAChangelogParser/Services/ChangelogTokenizer.cs
@@ -40,8 +40,12 @@ namespace KeepAChangelogParser.Services
       List<ChangelogToken> tokenCollection =
         new List<ChangelogToken>();
 
+#if NET8_0_OR_GREATER
       List<string> lineCollection = [..
-        text.Split(new[] { newLine }, StringSplitOptions.None)];
+        text.Split([newLine], StringSplitOptions.None)];
+#else
+      List<string> lineCollection = text.Split(new[] { newLine }, StringSplitOptions.None).ToList();
+#endif
 
       for (int lineNumber = 1; lineNumber <= lineCollection.Count; lineNumber++)
       {
@@ -68,10 +72,17 @@ namespace KeepAChangelogParser.Services
               lineCollection[lineNumber - 1],
               startIndex);
 
+#if NET8_0_OR_GREATER
           List<IGrouping<int, ChangelogTokenMatch>> tokenMatchByStartIndexCollection = [..
             tokenMatchCollection.
               GroupBy(x => x.StartIndex).
               OrderBy(x => x.Key)];
+#else
+          List<IGrouping<int, ChangelogTokenMatch>> tokenMatchByStartIndexCollection = tokenMatchCollection.
+              GroupBy(x => x.StartIndex).
+              OrderBy(x => x.Key).
+              ToList();
+#endif
 
           ChangelogTokenMatch tokenMatch =
             tokenMatchByStartIndexCollection[0].
@@ -93,24 +104,20 @@ namespace KeepAChangelogParser.Services
         }
       }
 
-#if NETCOREAPP || NET5_0 || NET6_0 || NET8_0
-
+#if NET
       tokenCollection.Add(
         new ChangelogToken(
           ChangelogTokenType.NewLine,
           newLine,
           lineCollection.Count,
           lineCollection[^1].Length));
-
 #else
-
       tokenCollection.Add(
         new ChangelogToken(
           ChangelogTokenType.NewLine,
           newLine,
           lineCollection.Count,
           lineCollection[lineCollection.Count - 1].Length));
-
 #endif
 
       tokenCollection.Add(
@@ -158,10 +165,16 @@ namespace KeepAChangelogParser.Services
 
       foreach (ChangelogTokenDefinition tokenDefinition in this.tokenDefinitionCollection)
       {
+#if NET8_0_OR_GREATER
+        tokenMatchCollection.
+          AddRange(
+            [.. findMatches(tokenDefinition, lineNumber, text, startIndex)]);
+#else
         tokenMatchCollection.
           AddRange(
             findMatches(tokenDefinition, lineNumber, text, startIndex).
             ToList());
+#endif
       }
 
       return tokenMatchCollection;

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "rollForward": "feature",
-    "version": "8.0.303"
+    "rollForward": "latestMinor",
+    "version": "9.0.100"
   }
 }


### PR DESCRIPTION
* Added support for .NET Standard 2.0 / 2.1 which is still important for applications that cannot be in “modern .NET”.
* Updated the SDK to .NET 9 in all projects and fixed all analyzer bugs.
* Removed .NET Framework support from 4.6.1 because it is added by .NET Standard 2.0: https://learn.microsoft.com/en-us/dotnet/standard/net-standard?tabs=net-standard-2-0#select-net-standard-version
* Removed .NET 5 because it is no longer supported: https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core

I had to ignore a rule (in .editorconfig) because it gives false positives.